### PR TITLE
fix forgotten template path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.myjavadoc</groupId>
   <artifactId>hibernate4-maven-plugin</artifactId>
-  <version>1.0.Beta1</version>
+  <version>1.1.Beta1</version>
   <packaging>maven-plugin</packaging>
 
   <name>hibernate4-maven-plugin Maven Plugin</name>
@@ -77,7 +77,7 @@
 	<dependency>
     	<groupId>org.hibernate</groupId>
     	<artifactId>hibernate-tools</artifactId>
-    	<version>4.3.4.Final</version>
+    	<version>4.3.5.Final</version>
 	</dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/src/main/java/com/myjavadoc/hibernate4/exporter/Hbm2JavaGeneratorMojo.java
+++ b/src/main/java/com/myjavadoc/hibernate4/exporter/Hbm2JavaGeneratorMojo.java
@@ -41,7 +41,9 @@ import com.myjavadoc.hibernate4.HibernateExporterMojo;
 public class Hbm2JavaGeneratorMojo
     extends HibernateExporterMojo
 {
-    /**
+    private static final String FALSE = "false";
+
+	/**
      * Default constructor.
      */
     public Hbm2JavaGeneratorMojo()
@@ -73,8 +75,19 @@ public class Hbm2JavaGeneratorMojo
         POJOExporter exporter = (POJOExporter) super.configureExporter( exp );
         
         // now set the extra properties for the POJO Exporter
-        exporter.getProperties().setProperty( "ejb3", getComponentProperty( "ejb3", "false" ) );
-        exporter.getProperties().setProperty( "jdk5", getComponentProperty( "jdk5", "false" ) );
+        exporter.getProperties().setProperty( "ejb3", getComponentProperty( "ejb3", FALSE ) );
+        exporter.getProperties().setProperty( "jdk5", getComponentProperty( "jdk5", FALSE ) );
+
+        String template = getComponentProperty( "template", FALSE );
+        String templatepath = getComponentProperty( "templatepath", FALSE );
+        if(!template.equals(FALSE)) {
+        	exporter.setTemplateName(template);
+        }
+        if(!templatepath.equals(FALSE)) {
+        	String[] templatePaths = new String[1];
+        	templatePaths[0]=templatepath;
+        	exporter.setTemplatePath(templatePaths);
+        }
         return exporter;
     }
 


### PR DESCRIPTION
Hi, when I tried to configure custom templates in the hbm2java execution componentProperties, but the plugin ignore the template path. Here is my componentProperties section:

```
<componentProperties>
  <jdk5>true</jdk5>
  <ejb3>true</ejb3>
  <format>true</format>
  <packagename>${jpa.package}</packagename>
  <revengfile>src/main/resources/hibernate.reveng.xml</revengfile>
  <configurationfile>target/hibernate3/generated-mappings/hibernate.cfg.xml</configurationfile>
  <template>Pojo.ftl</template>
  <templatepath>src/main/resources/ftl/pojo/</templatepath>
</componentProperties>
```
I changed the code on the followng files